### PR TITLE
Bugfix 20260330

### DIFF
--- a/sailor-agent/app/datasource/dip_dataview.py
+++ b/sailor-agent/app/datasource/dip_dataview.py
@@ -69,7 +69,7 @@ def get_view_schema_of_table(source: dict, column: dict, zh_table, comment) -> d
         middle += "{column_en} {column_type} comment '{column_cn}'\n"
         middle = middle.format(
             column_en=entry["original_name"],
-            column_cn=entry["display_name"],
+            column_cn=entry["comment"],
             column_type=entry["type"],
         )
     schema = CREATE_SCHEMA_TEMPLATE.format(

--- a/sailor-agent/app/memory/repository.py
+++ b/sailor-agent/app/memory/repository.py
@@ -76,6 +76,13 @@ class MemoryRepository:
         for record in self._session.scalars(stmt):
             self._session.delete(record)
 
+    def delete_chunks_by_document_ids(self, ids: list[str]) -> None:
+        if not ids:
+            return
+        stmt = select(MemoryChunkRecord).where(MemoryChunkRecord.document_id.in_(ids))
+        for record in self._session.scalars(stmt):
+            self._session.delete(record)
+
     def list_documents(self, query: MemoryListQueryDTO) -> MemoryListResultDTO:
         """
         分页列出当前用户的记忆文档，支持按关键词和来源类型简单过滤。

--- a/sailor-agent/app/memory/service.py
+++ b/sailor-agent/app/memory/service.py
@@ -174,6 +174,8 @@ class MemoryService:
 
         def _inner(repo: MemoryRepository) -> None:
             logger.info("批量删除记忆文档：count=%d", len(ids))
+            # 当前模型未显式设置外键级联，先删向量块再删文档，避免孤儿 chunk
+            repo.delete_chunks_by_document_ids(ids)
             repo.delete_documents(ids)
 
         self._with_repo(_inner)

--- a/sailor-agent/app/memory/tools.py
+++ b/sailor-agent/app/memory/tools.py
@@ -129,3 +129,9 @@ class MemoryTools:
             self._service.upsert_documents(docs)
         return MemoryWriteToolOutput(written_ids=[d.id for d in docs])
 
+    def delete_documents(self, ids: list[str]) -> None:
+        """
+        物理删除记忆文档及其对应的向量块。
+        """
+        self._service.delete_documents(ids)
+

--- a/sailor-agent/app/tools/memory_tools/tool_impl.py
+++ b/sailor-agent/app/tools/memory_tools/tool_impl.py
@@ -107,15 +107,51 @@ class MemoryWriteTool:
           - title/location/metadata/source_type/datasource_id: 可选
         """
 
+        def _is_null_string(value: Any) -> bool:
+            # 只有当传入值本身是字符串 "null" 时才触发删除
+            return isinstance(value, str) and value.strip() == "null"
+
         try:
-            payload = MemoryWriteToolInput(
-                user_id=coerce_memory_user_id(params.get("user_id")),
-                documents=list(params.get("documents") or []),
-            )
+            raw_documents = list(params.get("documents") or [])
+
+            delete_ids: list[str] = []
+            remaining_documents: list[dict[str, Any]] = []
+
+            for item in raw_documents:
+                if not isinstance(item, dict):
+                    continue
+
+                if _is_null_string(item.get("text")) or _is_null_string(
+                    item.get("title")
+                ):
+                    raw_id = str(item.get("id") or "").strip()
+                    if raw_id:
+                        delete_ids.append(raw_id)
+                    else:
+                        logger.warning(
+                            "[MemoryWriteTool] 删除请求但缺少 id: text=%r title=%r",
+                            item.get("text"),
+                            item.get("title"),
+                        )
+                    continue
+
+                remaining_documents.append(item)
+
+            # 先物理删除，再写入其余条目
+            if delete_ids:
+                self._backend.delete_documents(list(set(delete_ids)))
+
+            written_ids: list[str] = []
+            if remaining_documents:
+                payload = MemoryWriteToolInput(
+                    user_id=coerce_memory_user_id(params.get("user_id")),
+                    documents=remaining_documents,
+                )
+                result = self._backend.write(payload)
+                written_ids = result.written_ids
         except Exception as exc:  # noqa: BLE001
             logger.error(f"[MemoryWriteTool] 参数解析失败: {exc}")
             return {"written_ids": []}
 
-        result = self._backend.write(payload)
-        return {"written_ids": result.written_ids}
+        return {"written_ids": written_ids}
 


### PR DESCRIPTION
1. text2sql 返回的视图的DDL语句中comment修改，之前DDL语句中的comment就是技术名称。导致大模型无法根据comment中的详细信息判断字段的额外信息，比如：字段单位等。比如字段的单位元还是万元，将直接影响SQL的准确性
2. 记忆写入功能没有删除操作，增加删除操作，将一些无用记忆删除掉。